### PR TITLE
Fixes images re-scaling on mobile

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
         <div class="column is-full-mobile is-half-desktop" style="border-radius: 1%; box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19)">
             <div class="is-flex" style="justify-content: center; border-radius: 3%; background-color: #f0f5f1; position: relative;">
                 <figure class="image"> 
-                    <img style="border-radius: 3%; width: {{.Params.Image_width}}px; height: {{.Params.Image_height}}px" src={{ printf "%s%s" .Site.BaseURL .Params.Recipe_image }} alt="Placeholder image">
+                    <img style="border-radius: 3%;" src="{{ $.Params.Recipe_image | absURL }}" alt="Placeholder image">
                 </figure>
                 <div id="printButton" style="position: absolute; bottom: 0; right: 0;" class="is-rounded">
                     <a href="/print/{{ urlize .File.BaseFileName }}/print.html" target="_blank"><i class="fas fa-print fa-3x"></i></a>


### PR DESCRIPTION

The current template produces images with different (anisotropic) scaling in mobile and desktop, as shown below. This workaround (which can probably be done better, I am not good with html) solves it.

On mobile:

<img width="439" alt="Screen Shot 2022-03-20 at 6 41 16 PM" src="https://user-images.githubusercontent.com/30415788/159189108-ce3a8f06-0c80-4077-8131-5ad50adb932a.png">

On desktop:

<img width="1149" alt="Screen Shot 2022-03-20 at 6 41 42 PM" src="https://user-images.githubusercontent.com/30415788/159189128-c82746aa-3146-4040-b15a-a86f493d6422.png">

