### PR TITLE
Generate proper relative urls for github/gitlab pages

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,7 +7,7 @@
                     <img style="border-radius: 3%; width: {{.Params.Image_width}}px; height: {{.Params.Image_height}}px" src={{ printf "%s%s" .Site.BaseURL .Params.Recipe_image }} alt="Placeholder image">
                 </figure>
                 <div id="printButton" style="position: absolute; bottom: 0; right: 0;" class="is-rounded">
-                    <a href="/print/{{ urlize .File.BaseFileName }}/print.html" target="_blank"><i class="fas fa-print fa-3x"></i></a>
+                    <a href="{{printf "/print/%s/print.html" (.File.BaseFileName  | urlize)  | urlize | relURL }}" target="_blank"><i class="fas fa-print fa-3x"></i></a>
                 </div>
             </div>
             

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,9 +1,9 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg">
-    <link rel="stylesheet" type="text/css" href="/css/bulma.min.css">
-    <link rel="stylesheet" type="text/css" href="/css/custom.css">
+    <link rel="icon" type="image/svg+xml" href="{{ "/images/favicon.svg" | urlize | relURL}}">
+    <link rel="stylesheet" type="text/css" href="{{ "/css/bulma.min.css" | urlize | relURL}}">
+    <link rel="stylesheet" type="text/css" href="{{ "/css/custom.css" | urlize | relURL}}">
     <script src="https://kit.fontawesome.com/b7002cebe4.js" crossorigin="anonymous"></script>
     {{ $title := print .Site.Title " | " .Title }}
     {{ if .IsHome }}{{ $title = .Site.Title }}{{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,7 @@
     <div class="navbar-brand">
         <a class="navbar-brand">
             {{ with .Site.Params.logo }}
-                <img src="{{ .filename }}" width="{{ .width }}" height="{{ .height }}">
+                <img src="{{ .filename | urlize | relURL }}" width="{{ .width }}" height="{{ .height }}">
             {{ else }}
                 <h1 style="font-size:300%"><em>{{ .Site.Params.navText.text }}</em></h1>
             {{ end }}

--- a/layouts/partials/printhead.html
+++ b/layouts/partials/printhead.html
@@ -1,7 +1,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" type="text/css" href="/css/bulma.min.css">
+    <link rel="stylesheet" type="text/css" href="{{ "/css/bulma.min.css" | urlize | relURL}}">
     <script src="https://kit.fontawesome.com/b7002cebe4.js" crossorigin="anonymous"></script>
     {{ $title := print .Site.Title " | " .Title }}
     {{ if .IsHome }}{{ $title = .Site.Title }}{{ end }}

--- a/layouts/partials/printscript.html
+++ b/layouts/partials/printscript.html
@@ -1,2 +1,2 @@
-<script src="/js/umbrella.min.js"></script>
-<script src="/js/print.js"></script>
+<script src="{{ "/js/umbrella.min.js" | urlize | relURL}}"></script>
+<script src="{{ "/js/print.js" | urlize | relURL}}"></script>

--- a/layouts/partials/script.html
+++ b/layouts/partials/script.html
@@ -1,5 +1,5 @@
-<script src="/js/umbrella.min.js"></script>
-<script src="/js/custom.js"></script>
-<script src="/js/menu.js"></script>
+<script src="{{ "/js/umbrella.min.js" | urlize | relURL}}"></script>
+<script src="{{ "/js/custom.js" | urlize | relURL}}"></script>
+<script src="{{ "/js/menu.js" | urlize | relURL}}"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/fuse.js/3.2.0/fuse.min.js"></script>
 

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -42,7 +42,7 @@ u('#searchButton').handle('click', function(e) { //use handle to automatically p
 })
 
 function executeSearch(searchQuery){
-    fetch("{{ "/index.json" | urlize | relURL}}").then(r => r.json())
+  fetch("/index.json").then(r => r.json())
     .then(function(data) {    
         var pages = data;
         var fuse = new Fuse(pages, fuseOptions);

--- a/static/js/custom.js
+++ b/static/js/custom.js
@@ -42,7 +42,7 @@ u('#searchButton').handle('click', function(e) { //use handle to automatically p
 })
 
 function executeSearch(searchQuery){
-    fetch("/index.json").then(r => r.json())
+    fetch("{{ "/index.json" | urlize | relURL}}").then(r => r.json())
     .then(function(data) {    
         var pages = data;
         var fuse = new Fuse(pages, fuseOptions);


### PR DESCRIPTION
I used some hugo functions to generate proper urls to static files since I couldn't get them running with github/gitlab pages.

I couldn't find a way to dynamically generate the link in the java script. (Now hardcoded "/index.json")
static/js/custom.js
So on github/gitlab pages the search might be broken.